### PR TITLE
Add TCP-only option; implement IDisposable; fix typos

### DIFF
--- a/P2PNET.Test/ObjectTests.cs
+++ b/P2PNET.Test/ObjectTests.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 namespace P2PNET.Test
 {
     [TestFixture]
-    class ObjectTests
+    class ObjectTests: IDisposable
     {
         private ObjectManager objMgr;
 
@@ -35,7 +35,7 @@ namespace P2PNET.Test
 
             string ipAddress = IPAddress.Loopback.ToString();
 
-            await objMgr.DirrectConnectAsyncTCP(ipAddress);
+            await objMgr.DirectConnectAsyncTCP(ipAddress);
 
             int peerCount = objMgr.KnownPeers.Count;
 
@@ -264,6 +264,11 @@ namespace P2PNET.Test
             }
 
             return true;
+        }
+
+        public void Dispose()
+        {
+            ((IDisposable)objMgr).Dispose();
         }
 
 

--- a/P2PNET.Test/TransportTests.cs
+++ b/P2PNET.Test/TransportTests.cs
@@ -9,7 +9,7 @@ using System.Text;
 namespace P2PNET.Test
 {
     [TestFixture]
-    public class ConnectionTests
+    public sealed class ConnectionTests: IDisposable
     {
         private TransportManager transMgr;
         TransportManager transManger2;
@@ -33,7 +33,7 @@ namespace P2PNET.Test
 
             string ipAddress = IPAddress.Loopback.ToString();
 
-            await transMgr.DirrectConnectAsyncTCP(ipAddress);
+            await transMgr.DirectConnectAsyncTCP(ipAddress);
 
             int peerCount = transMgr.KnownPeers.Count;
 
@@ -59,7 +59,7 @@ namespace P2PNET.Test
 
             string ipAddress = IPAddress.Loopback.ToString();
 
-            await transMgr.DirrectConnectAsyncTCP(ipAddress);
+            await transMgr.DirectConnectAsyncTCP(ipAddress);
 
             Assert.IsTrue(msgReceived == false);
         }
@@ -98,7 +98,7 @@ namespace P2PNET.Test
             string ipAddress = IPAddress.Loopback.ToString();
 
             //make sure the local peer is known
-            await transMgr.DirrectConnectAsyncTCP(ipAddress);
+            await transMgr.DirectConnectAsyncTCP(ipAddress);
 
             byte[] SendMsg = new byte[] { 255, 0, 153, 00 };
             await transMgr.SendToAllPeersAsyncUDP(SendMsg);
@@ -177,5 +177,43 @@ namespace P2PNET.Test
             }
             return sb.ToString();
         }
+
+        #region IDisposable Support
+        private bool disposedValue = false; // To detect redundant calls
+
+        void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    // TODO: dispose managed state (managed objects).
+                    ((IDisposable)transManger2).Dispose();
+                    ((IDisposable)transMgr).Dispose();
+                }
+
+                // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
+                // TODO: set large fields to null.
+
+                disposedValue = true;
+            }
+        }
+
+        // TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources.
+        // ~ConnectionTests() {
+        //   // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+        //   Dispose(false);
+        // }
+
+        // This code added to correctly implement the disposable pattern.
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+            Dispose(true);
+            // TODO: uncomment the following line if the finalizer is overridden above.
+            // GC.SuppressFinalize(this);
+        }
+        #endregion
+
     }
 }

--- a/P2PNET/ObjectLayer/ObjectManager.cs
+++ b/P2PNET/ObjectLayer/ObjectManager.cs
@@ -12,7 +12,7 @@ namespace P2PNET.ObjectLayer
     /// Class for sending and receiving objects between peers.
     /// Built on top of TransportManager.
     /// </summary>
-    public class ObjectManager
+    public class ObjectManager: IDisposable
     {
         /// <summary>
         /// Triggered when a new peer is detected or an existing peer becomes inactive
@@ -43,9 +43,9 @@ namespace P2PNET.ObjectLayer
         /// </summary>
         /// <param name="mPortNum"> The port number which this peer will listen on and send messages with </param>
         /// <param name="mForwardAll"> When true, all messages received trigger a MsgReceived event. This includes UDB broadcasts that are reflected back to the local peer.</param>
-        public ObjectManager(int mPortNum = 8080, bool mForwardAll = false, ILogger mLogger = null)
+        public ObjectManager(int mPortNum = 8080, bool mForwardAll = false, ILogger mLogger = null, bool tcpOnly = false)
         {
-            peerManager = new TransportManager(mPortNum, mForwardAll, mLogger);
+            peerManager = new TransportManager(mPortNum, mForwardAll, mLogger, tcpOnly);
             serializer = new Serializer();
 
             peerManager.MsgReceived += PeerManager_msgReceived;
@@ -139,9 +139,9 @@ namespace P2PNET.ObjectLayer
         /// </summary>
         /// <param name="ipAddress">the ip address to establish a connection with</param>
         /// <returns></returns>
-        public async Task DirrectConnectAsyncTCP(string ipAddress)
+        public async Task DirectConnectAsyncTCP(string ipAddress)
         {
-            await peerManager.DirrectConnectAsyncTCP(ipAddress);
+            await peerManager.DirectConnectAsyncTCP(ipAddress);
         }
 
         private async Task<byte[]> PackObjectIntoMsg<T>(T obj)
@@ -182,6 +182,11 @@ namespace P2PNET.ObjectLayer
             Metadata metadata = obj.GetMetadata();
             metadata.BindType = e.BindingType;
             ObjReceived?.Invoke(this, new ObjReceivedEventArgs(obj, metadata));
+        }
+
+        public void Dispose()
+        {
+            ((IDisposable)peerManager).Dispose();
         }
     }
 }

--- a/P2PNET/TransportLayer/Listener.cs
+++ b/P2PNET/TransportLayer/Listener.cs
@@ -37,11 +37,12 @@ namespace P2PNET.TransportLayer
         private int portNum;
 
         //constructor
-        public Listener(int mPortNum)
+        public Listener(int mPortNum, bool mTcpOnly=false)
         {
             isListening = false;
 
-            this.listenerUDP = new UdpSocketReceiver();
+            if (!mTcpOnly)
+                this.listenerUDP = new UdpSocketReceiver();
             this.listenerTCP = new TcpSocketListener();
 
             this.portNum = mPortNum;
@@ -50,14 +51,15 @@ namespace P2PNET.TransportLayer
         //destory connection
         public void Dispose()
         {
-            listenerUDP.Dispose();
+            listenerUDP?.Dispose();
             listenerTCP.Dispose();
         }
 
         public async Task StartAsync()
         {
             await StartListeningAsyncTCP(this.portNum);
-            await StartListeningAsyncUDP(this.portNum);
+            if (listenerUDP != null)
+                await StartListeningAsyncUDP(this.portNum);
             isListening = true;
         }
 
@@ -116,6 +118,9 @@ namespace P2PNET.TransportLayer
 
         private async Task StartListeningAsyncUDP(int portNum)
         {
+            if (listenerUDP == null)
+                throw new InvalidOperationException("Cannot listen on UDP when in TCP only mode.");
+
             listenerUDP.MessageReceived += ListenerUDP_MessageReceived;
             await listenerUDP.StartListeningAsync(portNum);
 

--- a/P2PNET/TransportLayer/WriteStreamUtil.cs
+++ b/P2PNET/TransportLayer/WriteStreamUtil.cs
@@ -11,6 +11,7 @@ namespace P2PNET.TransportLayer
 {
     class WriteStreamUtil : AbstractStreamUtil
     {
+        private SemaphoreSlim queueSem = new SemaphoreSlim(1);
         private SemaphoreSlim messageSem = new SemaphoreSlim(1);
 
         private Queue<byte[]> msgBuffer;
@@ -24,18 +25,35 @@ namespace P2PNET.TransportLayer
         public async Task WriteBytesAsync(byte[] msg)
         {
             //add message to buffer
-            msgBuffer.Enqueue(msg);
+            await queueSem.WaitAsync();
+            try
+            {
+                msgBuffer.Enqueue(msg);
+            }
+            finally
+            {
+                queueSem.Release();
+            }
 
             //make sure only one message is sent at a time
             await messageSem.WaitAsync();
             try
             {
-                //read next message from buffer
-                if (msgBuffer.Count <= 0)
+                byte[] nextMsg;
+                await queueSem.WaitAsync();
+                try
                 {
-                    throw new LowLevelTransitionError("Expected more messages in the write buffer.");
+                    //read next message from buffer
+                    if (msgBuffer.Count <= 0)
+                    {
+                        throw new LowLevelTransitionError("Expected more messages in the write buffer.");
+                    }
+                    nextMsg = msgBuffer.Dequeue();
                 }
-                byte[] nextMsg = msgBuffer.Dequeue();
+                finally
+                {
+                    queueSem.Release();
+                }
 
                 //send number indicating message size
                 int lenMsg = (int)nextMsg.Length;


### PR DESCRIPTION
For a use case requiring a TCP-only peer connection, added a tcpOnly flag to the constructor in ObjectManager, TransportLayer, BaseStation, and Listener. This simply disables all UDP functionality, and causes all attempts to send UDP to throw InvalidOperationException.

Also implemented IDisposable to ensure connections are closed, rather than rely on finalizers.

In addition I fixed a few typos / counter-intuitive method in my copy - Dirrect vs. Direct, and Send TCP vs. UDP - could also add back the old names and mark with Obsolete attribute if required for backward compatibility.